### PR TITLE
Add AGENTS guidelines and project memory bank

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENT Instructions
+
+## Scope
+These guidelines apply to the entire repository.
+
+## Required Checks
+- Run `npm run lint` and `npm test` after making changes. If dependencies are missing and commands fail, note this in the PR.
+
+## Memory Bank
+- Maintain the `memory-bank/` directory. Update `activeContext.md` and `progress.md` with significant changes or new learnings.
+
+## Style
+- Follow existing TypeScript style and use ESLint for consistency.
+

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,0 +1,4 @@
+# Active Context
+
+- Initial memory bank created to support persistent documentation between sessions.
+- No outstanding development tasks yet. Future work will follow contribution guidelines (npm run lint, npm test) when dependencies are installed.

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,0 +1,3 @@
+# Product Context
+
+MCP allows applications to separate context provisioning from LLM interaction. This SDK enables Node.js developers to expose data, tools, and prompts via standardized transports (stdio, HTTP, WebSockets) and provides client utilities to consume those services. The aim is to streamline LLM integration workflows and foster interoperability between MCP-compatible tools.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,0 +1,4 @@
+# Progress
+
+- Memory bank initialized with project overview and context files.
+- Ready for future tasks and contributions.

--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -1,0 +1,3 @@
+# Project Brief
+
+This repository contains the TypeScript SDK for the Model Context Protocol (MCP). The goal of the project is to provide a complete client and server implementation of the MCP specification so that developers can easily build MCP servers and clients in TypeScript/JavaScript environments. The SDK supports multiple transports and provides utilities for OAuth, tools, resources, and prompts.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -1,0 +1,8 @@
+# System Patterns
+
+- **Typed schemas** defined in `src/types.ts` using Zod provide validation and TypeScript types.
+- **Protocol** logic in `src/shared/protocol.ts` coordinates requests, responses, and notifications over a pluggable `Transport` interface.
+- **Server** implementation in `src/server/` extends `Protocol` and handles initialization, capability negotiation, and OAuth flows. `src/server/mcp.ts` offers high-level APIs for registering tools, resources, and prompts.
+- **Client** implementation in `src/client/` mirrors the server and supports multiple transports.
+- **Transports** (stdio, Streamable HTTP, SSE, WebSocket) live under `src/server/` and `src/client/` folders.
+- Builds produce ESM and CJS output under `dist/` using separate TypeScript configs.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -1,0 +1,8 @@
+# Tech Context
+
+- **Node.js >=18** is required.
+- Written in **TypeScript** (tsc, ts-node/tsx for running examples).
+- Testing uses **Jest** with `ts-jest`.
+- Linting via **ESLint**.
+- Uses **express** and related libraries for HTTP transports.
+- `zod` provides runtime validation.


### PR DESCRIPTION
## Summary
- establish persistent documentation under `memory-bank/`
- add `AGENTS.md` with repo instructions for Codex

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2749dfa883319eacd79b1313768c