### PR TITLE
Add repository guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,3 +845,13 @@ Issues and pull requests are welcome on GitHub at <https://github.com/modelconte
 ## License
 
 This project is licensed under the MIT License—see the [LICENSE](LICENSE) file for details.
+
+## Repository Guide
+
+This repository contains several documentation files that provide important context for contributors and AI agents. Start with these resources to navigate the codebase effectively:
+
+- [AGENTS.md](AGENTS.md) – contributor rules and automation guidelines.
+- [memory-bank/](memory-bank/) – persistent project context starting with [projectbrief.md](memory-bank/projectbrief.md).
+- [CLAUDE.md](CLAUDE.md) – build commands and coding conventions.
+- [src/examples/README.md](src/examples/README.md) – example servers and clients.
+

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -3,3 +3,4 @@
 - Memory bank expanded with `codeOverview.md` detailing key files and directories.
 - No dependencies installed yet, so `npm run lint` and `npm test` fail.
 - Continue deepening documentation and exploring repository structure.
+- Added "Repository Guide" section to README pointing to AGENTS.md, memory-bank, CLAUDE.md, and example README.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2,3 +2,4 @@
 
 - Memory bank initialized with project overview and context files.
 - Added detailed `codeOverview.md` mapping directories and files.
+- Introduced new "Repository Guide" section in README for quick navigation.


### PR DESCRIPTION
## Summary
- add a new *Repository Guide* section in the main README linking to docs used by AI agents
- record the addition in `activeContext.md` and `progress.md`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b46468d60833191f66226bd41c424